### PR TITLE
Added Panther Point & Ibex Peak Ignition success, Improved table

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Currently this tool:
 
 Current status:
 
-| PCH           | CPU           | SKU      | Status		 |
-|:-------------:|:-------------:|:--------:|:---------:|
-| Ibex Peak     | Nehalem       | Ignition | **WORKS** |
-| Ibex Peak     | Nehalem       | 1.5/5MB	 | DOESN'T WORK (yet) |
-| Cougar Point  | Sandy Bridge	| 1.5/5MB  | UNTESTED |
-| Panther Point | Ivy Bridge	  | 1.5/5MB  | **WORKS** |
-| Lynxt Point   | Haswell       | 1.5/5MB	 | UNTESTED |
-| Lynxt Point   | Broadwell	    | 1.5/5MB  | UNTESTED |
-| Sunrise Point | Skylake	      | CON/COR  | UNTESTED |
-| Union Point   | Kabylake	    | CON/COR  | UNTESTED |
+| PCH           | CPU           | ME | SKU      | Status		 |
+|:-------------:|:-------------:|:---|:--------:|:---------:|
+| Ibex Peak     | Nehalem       | 6.0 | Ignition | **WORKS** |
+| Ibex Peak     | Nehalem       | 6.x | 1.5/5MB	 | DOESN'T WORK (yet) |
+| Cougar Point  | Sandy Bridge	| 7.x | 1.5/5MB  | UNTESTED |
+| Panther Point | Ivy Bridge	  | 8.x | 1.5/5MB  | **WORKS** |
+| Lynx/Wildcat Point   | Haswell/Broadwell       | 9.x | 1.5/5MB	 | UNTESTED |
+| Wildcat  Point LP   | Broadwell Mobile	    | 10.0 | 1.5/5MB  | UNTESTED |
+| Sunrise Point | Skylake/Kabylake	      | 11.x | CON/COR  | UNTESTED |
+| Union Point   | Kabylake	    | 11.6 | CON/COR  | UNTESTED |

--- a/README.md
+++ b/README.md
@@ -16,12 +16,13 @@ Currently this tool:
 
 Current status:
 
-| Architecture  | Status		|
-|---------------|-----------------------|
-| Nehalem	| DOESN'T WORK (yet)	|
-| Sandy Bridge	| UNTESTED		|
-| Ivy Bridge	| UNTESTED		|
-| Haswell	| UNTESTED		|
-| Broadwell	| UNTESTED		|
-| Skylake	| UNTESTED		|
-
+| PCH           | CPU           | SKU      | Status		 |
+|:-------------:|:-------------:|:--------:|:---------:|
+| Ibex Peak     | Nehalem       | Ignition | **WORKS** |
+| Ibex Peak     | Nehalem       | 1.5/5MB	 | DOESN'T WORK (yet) |
+| Cougar Point  | Sandy Bridge	| 1.5/5MB  | UNTESTED |
+| Panther Point | Ivy Bridge	  | 1.5/5MB  | **WORKS** |
+| Lynxt Point   | Haswell       | 1.5/5MB	 | UNTESTED |
+| Lynxt Point   | Broadwell	    | 1.5/5MB  | UNTESTED |
+| Sunrise Point | Skylake	      | CON/COR  | UNTESTED |
+| Union Point   | Kabylake	    | CON/COR  | UNTESTED |


### PR DESCRIPTION
Hello,

Based on some observations done [here](http://www.win-raid.com/t2443f39-Remove-ME-Ignition-firmware-completely-amp-Panther-Point-PCH-observations.html#msg33301), I've added PPT and IBX IGN SKU as "working" and also enriched the success table. ME6 IGN does not seem to have LZMA modules so removing the rest of the $FPT regions works by itself. Everything else like removing Huffman modules or moving the FTPR up etc do not matter though as ME6 IGN can work even without a ME region at all, as shown above.