### PR TITLE
Fix flash descriptor permissions

### DIFF
--- a/me_cleaner.py
+++ b/me_cleaner.py
@@ -797,7 +797,7 @@ if __name__ == "__main__":
     if args.descriptor:
         print("Removing ME/TXE R/W access to the other flash regions...")
         if me11:
-            flmstr2 = 0x00400400
+            flmstr2 = 0x00400500
         else:
             fdf.seek(fmba + 0x4)
             flmstr2 = (unpack("<I", fdf.read(4))[0] | 0x04040000) & 0x0404ffff


### PR DESCRIPTION
ME read access on the flash descriptor is (at least on some systems)
needed to complete boot process.

(Please check byte order for ME<v11. Not sure if it is correct...)

#154 
