### PR TITLE
Add soft-disable support for Intel ME 12, 14, 15 and 16

### DIFF
--- a/me_cleaner.py
+++ b/me_cleaner.py
@@ -665,15 +665,17 @@ if __name__ == "__main__":
             gen = 3
             num_entries = unpack("<I", mef.read(4))[0]
 
-            mef.seek(ftpr_offset + 0x10)
-            data = mef.read(0x18)
+            mef.seek(ftpr_offset + 0x14)
+            data = mef.read(0x8)
 
             ## Intel ME version >= 15 seems to have 4 more bytes ##
-            intel_me_15 = bytes([0xDA, 0x3D, 0xC8, 0xE5])
-            intel_me_16 = bytes([0x0D, 0xA2, 0xFA, 0xED])
-
-            if intel_me_15 in data or intel_me_16 in data:
+            ## I think the 4 bytes have to do something with Intel ME version or date, ##
+            ## but not sure. ##
+            ## Check for 'FTPR.man' ##
+            if bytes([0x46, 0x54, 0x50, 0x52, 0x2E, 0x6D, 0x61, 0x6E]) == data:
                 mef.seek(ftpr_offset + 0x14)
+            else:
+                mef.seek(ftpr_offset + 0x10)
 
             ftpr_mn2_offset = -1
 


### PR DESCRIPTION
I haven't tested with others Intel ME for the 15 version, but I guess that should work, as the PCI device (Intel ME) is not present anymore and seems to act like it's disabled, but I'll need to do more tests with AMT to be sure.

If someone is looking at this pull request and is willing to test the soft-disable, since Intel ME 15 might have different HAP bit offsets between chipsets etc, although I'm not really sure about that, I don't have any other computers to test with.

Thanks to @dt-zero and @6d6178667269747a for previous versions of Intel ME.

If that doesn't work, try this guess:
https://github.com/corna/me_cleaner/pull/384#issuecomment-1220260578